### PR TITLE
Error in Obfuscation

### DIFF
--- a/src/UniqueCodes.php
+++ b/src/UniqueCodes.php
@@ -228,7 +228,7 @@ class UniqueCodes
 
             $string = $characters[$digit].$string;
 
-            $number = $number / strlen($characters);
+            $number = floor($number / strlen($characters));
         }
 
         return $string;


### PR DESCRIPTION
PHP Deprecated:  Implicit conversion from float 207428.18181818182 to int loses precision in C:\laragon\www\vouchers\vendor\nextapps\unique-codes\src\UniqueCodes.php on line 227

Was getting the error above.

Update Corrects the  Error